### PR TITLE
Add grpc cli dockerfile

### DIFF
--- a/grpc_cli/Dockerfile
+++ b/grpc_cli/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.7 as builder
+
+RUN set -xe \
+    && apk add --no-cache \
+        autoconf \
+        automake \
+        build-base \
+        cmake \
+        git \
+        libtool \
+        zlib-dev
+
+ARG GRPC_VERSION
+
+RUN if [[ -z "$GRPC_VERSION" ]]; then echo "GRPC_VERSION argument MUST be set" && exit 1; fi
+
+RUN git clone --depth 1 --recursive -b v${GRPC_VERSION} https://github.com/grpc/grpc.git /grpc
+
+ENV LDFLAGS=-static
+
+RUN cd /grpc/third_party/gflags \
+    && mkdir build && cd build \
+    && cmake -DBUILD_SHARED_LIBS=0 -DGFLAGS_INSTALL_SHARED_LIBS=0 .. \
+    && make -j2 \
+    && make install
+
+RUN cd /grpc && make -j2 grpc_cli
+
+
+FROM scratch
+COPY --from=builder /grpc/bins/opt/grpc_cli /grpc_cli
+COPY --from=builder /grpc/etc/roots.pem /usr/local/share/grpc/roots.pem
+
+ENTRYPOINT ["/grpc_cli"]
+CMD ["help"]

--- a/grpc_cli/README.md
+++ b/grpc_cli/README.md
@@ -1,0 +1,25 @@
+# gRPC CLI Docker image
+**Docker image for [gRPC CLI](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md)**
+
+## Usage
+```bash
+$ docker pull jcorral/docker-library:grpc-cli
+$ docker run --rm -it jcorral/docker-library:grpc-cli
+```
+
+### Aliasing grpc_cli
+```bash
+$ alias grpc_cli='docker run --rm -it jcorral/docker-library:grpc-cli'
+```
+
+## Troubleshooting
+### Getting `Method name not found` when calling to localhost
+
+Since the tool runs inside a container, localhost does not actually mean the host computer.
+
+On Linux you will have to find your host's IP address in the docker network and use that instead of `localhost` or `127.0.0.1`.
+
+On [Mac](https://docs.docker.com/docker-for-mac/networking/#per-container-ip-addressing-is-not-possible) you can use the special `docker.for.mac.localhost` host which resolves to the host's internal IP address.
+
+## License
+The MIT License (MIT). Please see [License File](LICENSE) for more information.


### PR DESCRIPTION
This MR adds grpc_cli Dockerfile that is intended to be used as a personal CLI to test GRPC endpoints.
